### PR TITLE
Try both old and new buffer protocols on python2.7

### DIFF
--- a/src/wxpybuffer.h
+++ b/src/wxpybuffer.h
@@ -31,8 +31,9 @@ public:
         #if PY_MAJOR_VERSION < 3
             // Old buffer protocol
             int rv = PyObject_AsReadBuffer(obj, (const void**)&m_ptr, &m_len);
-            return rv != -1;
-        #else
+            if (rv != -1)
+                return true;
+        #endif
             // New buffer protocol
             Py_buffer view;
             if (PyObject_GetBuffer(obj, &view, PyBUF_SIMPLE) != 0)
@@ -41,7 +42,6 @@ public:
             m_len = view.len;
             PyBuffer_Release(&view);
             return true;
-        #endif
     }
 
 


### PR DESCRIPTION
This is what I was trying to say in https://github.com/wxWidgets/Phoenix/pull/1679#issuecomment-647053707

I don't know if this is right or not, just trying to communicate via code rather than English is sometimes more effective.

